### PR TITLE
troubleshooting windows ci

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -49,8 +49,8 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
         with:
           precompile: true
-      - run: using BolometricCorrections; using DataDeps; datadep"PARSECv1.2S"; datadep"MISTv1.2_vvcrit0.0"; datadep"MISTv1.2_vvcrit0.4"; datadep"BaSTIv1"; datadep"BaSTIv2"
-        shell: julia --color=yes --project=@. {0}
+      - run: using StellarTracks; using DataDeps; datadep"PARSECv1.2S"; datadep"MISTv1.2_vvcrit0.0"; datadep"MISTv1.2_vvcrit0.4"; datadep"BaSTIv1"; datadep"BaSTIv2"
+        shell: julia --color=yes --project=@. -t 1 {0}
       - uses: julia-actions/julia-runtest@v1
         env:
           DATADEPS_ALWAYS_ACCEPT: 'true'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -50,7 +50,9 @@ jobs:
         with:
           precompile: true
       - run: using StellarTracks; using DataDeps; datadep"PARSECv1.2S"; datadep"MISTv1.2_vvcrit0.0"; datadep"MISTv1.2_vvcrit0.4"; datadep"BaSTIv1"; datadep"BaSTIv2"
-        shell: julia --color=yes --project=@. -t 1 {0}
+        shell: julia --color=yes --project=@. -t auto {0}
+        env:
+          DATADEPS_ALWAYS_ACCEPT: 'true'
       - uses: julia-actions/julia-runtest@v1
         env:
           DATADEPS_ALWAYS_ACCEPT: 'true'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,6 +47,10 @@ jobs:
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
+        with:
+          precompile: true
+      - run: using BolometricCorrections; using DataDeps; datadep"PARSECv1.2S"; datadep"MISTv1.2_vvcrit0.0"; datadep"MISTv1.2_vvcrit0.4"; datadep"BaSTIv1"; datadep"BaSTIv2"
+        shell: julia --color=yes --project=@. {0}
       - uses: julia-actions/julia-runtest@v1
         env:
           DATADEPS_ALWAYS_ACCEPT: 'true'

--- a/src/mist/init.jl
+++ b/src/mist/init.jl
@@ -97,6 +97,7 @@ function custom_unpack(fname::AbstractString)
     feh = string(mist_feh(fname))
     save_dir = joinpath(fpath, feh)
     if isdir(save_dir)
+        println("rm $save_dir")
         rm(save_dir; force=true, recursive=true)
     end
     mkdir(save_dir)
@@ -114,8 +115,12 @@ function custom_unpack(fname::AbstractString)
         # tdata = Table(tdata, m_ini = fill(header.M_ini, length(tdata)))
         # push!(alldata, tdata)
     end
+
+     Base.Sys.iswindows() && GC.gc() 
     # Remove temporary directory where .track.eep files were extracted
+    println("rm $out_dir")
     rm(out_dir; force=true, recursive=true)
+    println("rm $fname")
     rm(fname) # Remove original .txz file
 end
 

--- a/src/mist/init.jl
+++ b/src/mist/init.jl
@@ -87,7 +87,7 @@ function custom_unpack(fname::AbstractString)
     @info "Unpacking $fbasename"
     out_dir = joinpath(fpath, fbasename)
     if isdir(out_dir)
-        println("rm $out_dir")
+        @info "rm $out_dir"
         rm(out_dir; force=true, recursive=true)
     end
     # unpack_txz is imported from BolometricCorrections.MIST
@@ -98,7 +98,7 @@ function custom_unpack(fname::AbstractString)
     feh = string(mist_feh(fname))
     save_dir = joinpath(fpath, feh)
     if isdir(save_dir)
-        println("rm $save_dir")
+        @info "rm $save_dir"
         Base.Sys.iswindows() && GC.gc() 
         rm(save_dir; force=true, recursive=true)
     end
@@ -120,9 +120,9 @@ function custom_unpack(fname::AbstractString)
 
     Base.Sys.iswindows() && GC.gc() 
     # Remove temporary directory where .track.eep files were extracted
-    println("rm $out_dir")
+    @info "rm $out_dir"
     rm(out_dir; force=true, recursive=true)
-    println("rm $fname")
+    @info "rm $fname"
     rm(fname) # Remove original .txz file
 end
 

--- a/src/mist/init.jl
+++ b/src/mist/init.jl
@@ -87,9 +87,11 @@ function custom_unpack(fname::AbstractString)
     @info "Unpacking $fbasename"
     out_dir = joinpath(fpath, fbasename)
     @info "isdir(out_dir) $(isdir(out_dir)) $out_dir"
-    if isdir(out_dir)
-        rm(out_dir; force=true, recursive=true)
-    end
+    # if isdir(out_dir)
+    #     rm(out_dir; force=true, recursive=true)
+    # end
+    # If out_dir exists, this will remove it
+    rm(out_dir; force=true, recursive=true)
     # unpack_txz is imported from BolometricCorrections.MIST
     # It extracts the .txz, which is an Xz compressed tarball, into the out_dir
     unpack_txz(fname, out_dir)
@@ -98,11 +100,14 @@ function custom_unpack(fname::AbstractString)
     feh = string(mist_feh(fname))
     save_dir = joinpath(fpath, feh)
     @info "isdir(save_dir) $(isdir(save_dir)) $save_dir"
-    if isdir(save_dir)
-        Base.Sys.iswindows() && GC.gc() 
-        rm(save_dir; force=true, recursive=true)
-    end
-    mkdir(save_dir)
+    # if isdir(save_dir)
+    #     Base.Sys.iswindows() && GC.gc() 
+    #     rm(save_dir; force=true, recursive=true)
+    # end
+    # mkdir(save_dir)
+    # Clear save_dir; force=true does not error if non-existing
+    rm(save_dir; force=true, recursive=true)
+    mkpath(save_dir)
     files = filter(Base.Fix1(occursin, ".eep"), readdir(joinpath(out_dir, fbasename); join=true))
     for track in files
         data = read(track, String)

--- a/src/mist/init.jl
+++ b/src/mist/init.jl
@@ -86,8 +86,9 @@ function custom_unpack(fname::AbstractString)
     fbasename = splitext(basename(fname))[1]
     @info "Unpacking $fbasename"
     out_dir = joinpath(fpath, fbasename)
-    isdir(out_dir) && @info "rm $out_dir"
+    @info "isdir(out_dir) $(isdir(out_dir))"
     if isdir(out_dir)
+        @info "rm $out_dir"
         rm(out_dir; force=true, recursive=true)
     end
     # unpack_txz is imported from BolometricCorrections.MIST
@@ -118,7 +119,7 @@ function custom_unpack(fname::AbstractString)
         # push!(alldata, tdata)
     end
 
-    Base.Sys.iswindows() && GC.gc() 
+    Base.Sys.iswindows() && GC.gc()
     # Remove temporary directory where .track.eep files were extracted
     @info "rm $out_dir"
     rm(out_dir; force=true, recursive=true)

--- a/src/mist/init.jl
+++ b/src/mist/init.jl
@@ -86,9 +86,8 @@ function custom_unpack(fname::AbstractString)
     fbasename = splitext(basename(fname))[1]
     @info "Unpacking $fbasename"
     out_dir = joinpath(fpath, fbasename)
-    @info "isdir(out_dir) $(isdir(out_dir))"
+    @info "isdir(out_dir) $(isdir(out_dir)) $out_dir"
     if isdir(out_dir)
-        @info "rm $out_dir"
         rm(out_dir; force=true, recursive=true)
     end
     # unpack_txz is imported from BolometricCorrections.MIST
@@ -98,8 +97,8 @@ function custom_unpack(fname::AbstractString)
     # Now repack the .track.eep files, which are basic CSV, into JLD2
     feh = string(mist_feh(fname))
     save_dir = joinpath(fpath, feh)
+    @info "isdir(save_dir) $(isdir(save_dir)) $save_dir"
     if isdir(save_dir)
-        @info "rm $save_dir"
         Base.Sys.iswindows() && GC.gc() 
         rm(save_dir; force=true, recursive=true)
     end
@@ -121,9 +120,9 @@ function custom_unpack(fname::AbstractString)
 
     Base.Sys.iswindows() && GC.gc()
     # Remove temporary directory where .track.eep files were extracted
-    @info "rm $out_dir"
+    @info "isdir(out_dir) $(isdir(out_dir)) $out_dir"
     rm(out_dir; force=true, recursive=true)
-    @info "rm $fname"
+    @info "isfile(fname) $(isfile(fname)) $fname"
     rm(fname) # Remove original .txz file
 end
 

--- a/src/mist/init.jl
+++ b/src/mist/init.jl
@@ -87,6 +87,7 @@ function custom_unpack(fname::AbstractString)
     @info "Unpacking $fbasename"
     out_dir = joinpath(fpath, fbasename)
     if isdir(out_dir)
+        println("rm $out_dir")
         rm(out_dir; force=true, recursive=true)
     end
     # unpack_txz is imported from BolometricCorrections.MIST
@@ -98,6 +99,7 @@ function custom_unpack(fname::AbstractString)
     save_dir = joinpath(fpath, feh)
     if isdir(save_dir)
         println("rm $save_dir")
+        Base.Sys.iswindows() && GC.gc() 
         rm(save_dir; force=true, recursive=true)
     end
     mkdir(save_dir)
@@ -116,7 +118,7 @@ function custom_unpack(fname::AbstractString)
         # push!(alldata, tdata)
     end
 
-     Base.Sys.iswindows() && GC.gc() 
+    Base.Sys.iswindows() && GC.gc() 
     # Remove temporary directory where .track.eep files were extracted
     println("rm $out_dir")
     rm(out_dir; force=true, recursive=true)

--- a/src/mist/init.jl
+++ b/src/mist/init.jl
@@ -86,8 +86,8 @@ function custom_unpack(fname::AbstractString)
     fbasename = splitext(basename(fname))[1]
     @info "Unpacking $fbasename"
     out_dir = joinpath(fpath, fbasename)
+    isdir(out_dir) && @info "rm $out_dir"
     if isdir(out_dir)
-        @info "rm $out_dir"
         rm(out_dir; force=true, recursive=true)
     end
     # unpack_txz is imported from BolometricCorrections.MIST


### PR DESCRIPTION
problem with some remove command during MIST data install, see [here](https://github.com/cgarling/StellarTracks.jl/actions/runs/15769064034/job/44452954519), or below
```
[ Info: Unpacking MIST_v1.2_feh_m4.00_afe_p0.0_vvcrit0.0_EEPS
[ Info: Unpacking MIST_v1.2_feh_m3.50_afe_p0.0_vvcrit0.0_EEPS
[ Info: Unpacking MIST_v1.2_feh_m3.00_afe_p0.0_vvcrit0.0_EEPS
┌ Error: could not evaluate expression from doctest setup.
│   expression = :($(Expr(:toplevel, :(using StellarTracks), :(#= D:\a\StellarTracks.jl\StellarTracks.jl\test\runtests.jl:6 =#), :(import BolometricCorrections), :(#= D:\a\StellarTracks.jl\StellarTracks.jl\test\runtests.jl:6 =#), :(using DataDeps: @datadep_str), :(#= D:\a\StellarTracks.jl\StellarTracks.jl\test\runtests.jl:6 =#), :(datadep"PARSECv1.2S"), :(#= D:\a\StellarTracks.jl\StellarTracks.jl\test\runtests.jl:6 =#), :(datadep"MISTv1.2_vvcrit0.0"), :(#= D:\a\StellarTracks.jl\StellarTracks.jl\test\runtests.jl:6 =#), :(datadep"MISTv1.2_vvcrit0.4"), :(#= D:\a\StellarTracks.jl\StellarTracks.jl\test\runtests.jl:6 =#), :(datadep"BaSTIv1"), :(#= D:\a\StellarTracks.jl\StellarTracks.jl\test\runtests.jl:6 =#), :(datadep"BaSTIv2"))))
│   exception = IOError: rm("C:\\Users\\runneradmin\\.julia\\scratchspaces\\124859b0-ceae-595e-8997-d05f6a7a8dfe\\datadeps\\MISTv1.2_vvcrit0.0"): resource busy or locked (EBUSY)
└ @ Documenter C:\Users\runneradmin\.julia\packages\Documenter\uNI6f\src\doctests.jl:173
[ Info: Unpacking MIST_v1.2_feh_m4.00_afe_p0.0_vvcrit0.4_EEPS
[ Info: Unpacking MIST_v1.2_feh_m3.50_afe_p0.0_vvcrit0.4_EEPS
[ Info: Unpacking MIST_v1.2_feh_m3.00_afe_p0.0_vvcrit0.4_EEPS
┌ Error: could not evaluate expression from doctest setup.
│   expression = :($(Expr(:toplevel, :(using StellarTracks), :(#= D:\a\StellarTracks.jl\StellarTracks.jl\test\runtests.jl:6 =#), :(import BolometricCorrections), :(#= D:\a\StellarTracks.jl\StellarTracks.jl\test\runtests.jl:6 =#), :(using DataDeps: @datadep_str), :(#= D:\a\StellarTracks.jl\StellarTracks.jl\test\runtests.jl:6 =#), :(datadep"PARSECv1.2S"), :(#= D:\a\StellarTracks.jl\StellarTracks.jl\test\runtests.jl:6 =#), :(datadep"MISTv1.2_vvcrit0.0"), :(#= D:\a\StellarTracks.jl\StellarTracks.jl\test\runtests.jl:6 =#), :(datadep"MISTv1.2_vvcrit0.4"), :(#= D:\a\StellarTracks.jl\StellarTracks.jl\test\runtests.jl:6 =#), :(datadep"BaSTIv1"), :(#= D:\a\StellarTracks.jl\StellarTracks.jl\test\runtests.jl:6 =#), :(datadep"BaSTIv2"))))
│   exception = IOError: rm("C:\\Users\\runneradmin\\.julia\\scratchspaces\\124859b0-ceae-595e-8997-d05f6a7a8dfe\\datadeps\\MISTv1.2_vvcrit0.4"): resource busy or locked (EBUSY)
└ @ Documenter C:\Users\runneradmin\.julia\packages\Documenter\uNI6f\src\doctests.jl:173
```