### PR TITLE
Fix CSV.read for tuple `select_columns`

### DIFF
--- a/src/mist/init.jl
+++ b/src/mist/init.jl
@@ -57,14 +57,14 @@ function read_mist_track(data::AbstractString; select = nothing)
     header = parse_mist_header(data)
     # This works but is kind of slow; ~4--5 ms compared to the 100 μs to do read(filename, String)
     tdata = Table(CSV.File(IOBuffer(data); comment="#", delim=' ', ignorerepeated=true,
-                           header=header.colnames, select = select, ntasks=1))
+                           header=header.colnames, select=select, ntasks=1))
 end
 """
     track_table(filename::AbstractString; select = select_columns))
 Given the path to a MIST ".eep" track, read the file as a `TypedTables.Table`.
 `select` is passed through to `CSV.read` and can be used to select only certain columns.
 """
-function track_table(filename::AbstractString; select = select_columns)
+function track_table(filename::AbstractString; select = SVector(select_columns))
     result = read_mist_track(read(filename, String); select = select)
     if :Mbol in select
         @argcheck :log_L in select
@@ -104,7 +104,7 @@ function custom_unpack(fname::AbstractString)
     for track in files
         data = read(track, String)
         header = parse_mist_header(data)
-        tdata = read_mist_track(data; select = select_columns)
+        tdata = read_mist_track(data; select = SVector(select_columns))
         JLD2.save_object(joinpath(save_dir, splitext(basename(track))[1]) * ".jld2", tdata)
         # This takes up much more space because of multiple objects I guess?
         # JLD2.jldsave(joinpath(save_dir, splitext(basename(track))[1]) * ".jld2";

--- a/src/parsec/init.jl
+++ b/src/parsec/init.jl
@@ -27,7 +27,7 @@ track_matrix(filename::AbstractString) = readdlm(filename, ' ', track_type, '\n'
 Given the path to a PARSEC v1.2S ".dat" track, read the file as a `TypedTables.Table`.
 `select` is passed through to `CSV.read` and can be used to select only certain columns.
 """
-function track_table(filename::AbstractString, select = select_columns)
+function track_table(filename::AbstractString, select = SVector(select_columns))
     return CSV.read(filename, Table;
                     skipto = 2, header = Vector(track_header), types = track_type,
                     select = select) # utility

--- a/src/parsec/parsec.jl
+++ b/src/parsec/parsec.jl
@@ -49,7 +49,6 @@ const eep_idxs = NamedTuple{keys(eep_lengths)}((1, (cumsum(values(eep_lengths)[b
 const track_header = SVector{6, String}("logAge", "mass", "logTe", "Mbol", "logg", "C_O")
 const track_header_symbols = Tuple(Symbol.(i) for i in track_header)
 # Which columns to actually keep after reading track file; used in Track and track_table
-# const select_columns = SVector(:logAge, :logTe, :Mbol, :logg, :C_O)
 const select_columns = (:logAge, :logTe, :Mbol, :logg, :C_O)
 # Matrix columns to keep when reading track in track_matrix
 const keepcols = SVector(1,2,3,4,5,6)


### PR DESCRIPTION
We made `select_columns` a tuple today, need to convert to `SVector` before passing to CSV.read(...; select=SVector(select_columns))`.