### PR TITLE
Codecov ignore

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -56,6 +56,8 @@ jobs:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
+          ignore:
+	          - "**/init.jl"
 
   Aqua:
     name: Aqua Tests

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -57,7 +57,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
           ignore:
-	          - "**/init.jl"
+            - "**/init.jl"
 
   Aqua:
     name: Aqua Tests


### PR DESCRIPTION
The methods in the `init.jl` files are not run if the stellar track data files are hosted in a cache. Results in misleading coverage statistics, so ignore the init.jl files in code coverage.