### PR TITLE
Update for new MIST URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 This package provides access to and interpolation of pre-computed libraries of stellar tracks. Secondary operations like isochrone creation are also supported. Currently included libraries are
 
  - [PARSECv1.2S](https://stev.oapd.inaf.it/PARSEC/papers.html)
- - [MIST](https://waps.cfa.harvard.edu/MIST/index.html)
+ - [MIST](https://mist.science)
  - [BaSTIv1](http://basti-iac.oa-abruzzo.inaf.it/basti-old/) (older models, circa 2013)
  - [BaSTIv2](http://basti-iac.oa-abruzzo.inaf.it/index.html) (updated BaSTI tracks)
 

--- a/docs/src/mist.md
+++ b/docs/src/mist.md
@@ -16,7 +16,7 @@ using StellarTracks.MIST # load all exported methods
 using StellarTracks.MIST: MISTLibrary, X, Y, Z # load specific methods
 ```
 
-The main papers describing the MIST family of stellar models are [Dotter2016,Choi2016](@citet). The tracks as provided by the MIST team [here](https://waps.cfa.harvard.edu/MIST/model_grids.html) include the equivalent evolutionary points (EEPs) necessary to support robust isochrone creation and interpolation.
+The main papers describing the MIST family of stellar models are [Dotter2016,Choi2016](@citet). The tracks as provided by the MIST team [here](https://mist.science/model_grids.html) include the equivalent evolutionary points (EEPs) necessary to support robust isochrone creation and interpolation.
 
 The MIST library has been widely used as it covers the full range of stellar masses and metallicities relevant for most studies of stellar populations. MIST includes stars with initial stellar masses from 0.1 to 300 solar masses and initial metallicities ``-4 \le [\text{M}/\text{H}] \le 0.5``. MIST includes post-MS and post-RGB evolution (when appropriate). MIST also provides rotating (`vvcrit=0.4`) and non-rotating (`vvcrit=0.0`) models.
 
@@ -26,7 +26,7 @@ This package handles downloading and pre-processing of the MIST stellar tracks. 
 
 ## Table Details
 
-The user guide for the MIST products is available [here](https://waps.cfa.harvard.edu/MIST/README_overview.pdf). The full MIST tracks contain 77 data columns originating from the MESA output. An description of the columns is available [here](https://waps.cfa.harvard.edu/MIST/README_tables.pdf). **Currently, we process the raw tracks and only save the subset of columns given by `StellarTracks.MIST.select_columns` (see below).** These columns are the ones most commonly needed for computing isochrones and applying bolometric corrections to compare against observed stellar populations. This choice is an optimization for storage space, load time, and development simplicity. If you require access to more columns, please submit an issue on the source repository and we can consider options.
+The user guide for the MIST products is available [here](https://mist.science/README_overview.pdf). The full MIST tracks contain 77 data columns originating from the MESA output. An description of the columns is available [here](https://mist.science/README_tables.pdf). **Currently, we process the raw tracks and only save the subset of columns given by `StellarTracks.MIST.select_columns` (see below).** These columns are the ones most commonly needed for computing isochrones and applying bolometric corrections to compare against observed stellar populations. This choice is an optimization for storage space, load time, and development simplicity. If you require access to more columns, please submit an issue on the source repository and we can consider options.
 ```@example
 using StellarTracks.MIST
 MIST.select_columns # These columns are saved from raw tracks

--- a/src/mist/init.jl
+++ b/src/mist/init.jl
@@ -121,9 +121,10 @@ end
 
 
 function __init__()
+    v1_prefix = "https://mist.science/data/tarballs_v1.2/MIST_v1.2_feh_"
     norot_feh_tags = ["m4.00", "m3.50", "m3.00", "m2.50", "m2.00", "m1.75", "m1.50",
                       "m1.25", "m1.00", "m0.75", "m0.50", "m0.25", "p0.00", "p0.25", "p0.50"]
-    norot_dl_links = ["https://waps.cfa.harvard.edu/MIST/data/tarballs_v1.2/MIST_v1.2_feh_" * s * "_afe_p0.0_vvcrit0.0_EEPS.txz" for s in norot_feh_tags]
+    norot_dl_links = [v1_prefix * s * "_afe_p0.0_vvcrit0.0_EEPS.txz" for s in norot_feh_tags]
 
     # Register non-rotating models
     register(DataDep("MISTv1.2_vvcrit0.0",
@@ -135,7 +136,7 @@ function __init__()
                      post_fetch_method = custom_unpack))
 
     # Register rotating models
-    rot_dl_links = ["https://waps.cfa.harvard.edu/MIST/data/tarballs_v1.2/MIST_v1.2_feh_" * s * "_afe_p0.0_vvcrit0.4_EEPS.txz" for s in norot_feh_tags]
+    rot_dl_links = [v1_prefix * s * "_afe_p0.0_vvcrit0.4_EEPS.txz" for s in norot_feh_tags]
     register(DataDep("MISTv1.2_vvcrit0.4",
                      """MIST v1.2 stellar evolutionary tracks with rotation \
                      (v/vcrit=0.4). All available evolutionary tracks \


### PR DESCRIPTION
The MIST data have moved to a new url: https://mist.science/

This PR updates the necessary references to use the new url